### PR TITLE
Temporary Fix for map uplaods without server check

### DIFF
--- a/SteamBot/GroupChatHandler.cs
+++ b/SteamBot/GroupChatHandler.cs
@@ -1077,6 +1077,7 @@ namespace SteamBot
         /// <param name="Mapname">Mapname</param>
         public bool UploadCheck(string Mapname)
         {
+            return false;  //Error Check for Invalid Website needs to be added 
             if (Mapname.Contains("."))
             {
                 Mapname = (Mapname.Split(new string[] { "." }, System.StringSplitOptions.None)).First();
@@ -1087,7 +1088,6 @@ namespace SteamBot
             {
                 return true;
             }
-            return false;
         }
         ///<summary> Checks if the given STEAMID is an admin in the database</summary>
         public bool admincheck(SteamID sender)


### PR DESCRIPTION
http://redirect.tf2maps.net/maps/ doesn't return a valid string so
uploadcheck() fails. I've made it always return false due to this
